### PR TITLE
Add onnxruntime to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ imageio[ffmpeg]
 xatlas
 plyfile
 git+https://github.com/NVlabs/nvdiffrast/
+onnxruntime


### PR DESCRIPTION
I needed onnxruntime to run this. Alternatively if it doesn't belong in requirements perhaps the instructions can be updated to include `pip install onnxruntime`