### PR TITLE
Dockerfile minor fix: accept conda TOS

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,11 @@ ENV PATH="/workspace/miniconda3/bin:${PATH}"
 # initialize conda
 RUN conda init bash
 
+# accept conda tos
+ARG ACCEPT_CONDA_TOS
+RUN if [ "${ACCEPT_CONDA_TOS}" != "y" ] && [ "${ACCEPT_CONDA_TOS}" != "Y" ]; then echo "ERROR: You must accept the Conda TOS by setting ACCEPT_CONDA_TOS=y" && exit 1; fi
+RUN conda tos accept
+
 # create and activate conda environment
 RUN conda create -n instantmesh python=3.10 && echo "source activate instantmesh" > ~/.bashrc
 ENV PATH /workspace/miniconda3/envs/instantmesh/bin:$PATH

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,7 @@ make sure you are under directory `yourworkspace/instantmesh/`
 Build docker image:
 
 ```bash
-docker build -t instantmesh -f docker/Dockerfile .
+docker build -t instantmesh -f docker/Dockerfile --build-arg ACCEPT_CONDA_TOS=y .
 ```
 
 Run docker image with a local model cache (so it is fast when container is started next time):


### PR DESCRIPTION
The conda stuff in the dockerfile was failing for me unless I accepted the conda terms of service inside the container, this is a fix for that issue. Also I figured it might be legally dicey to autoaccept the TOS, so I added a build arg to make it "opt in".

Feedback welcome